### PR TITLE
CORS対策 対応

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -13,8 +13,11 @@ yoshikawa/django-starter-kit − learning about Django REST framework
 |Python|3.8.5|
 |Django|3.1|
 |Django REST framework|3.11.1|
+|django-cors-headers|3.4.0|
 
-Please check it! [Django REST framework](https://github.com/encode/django-rest-framework)
+Please check it! 
+[Django REST framework](https://github.com/encode/django-rest-framework)
+[django-cors-headers](https://github.com/adamchainz/django-cors-headers)
 
 ## Usage
 
@@ -23,16 +26,37 @@ Install using `pip`.
 ```sh
 pip install django
 pip install djangorestframework
+pip install django-cors-headers
 ```
 
-Add 'rest_framework' to your INSTALLED_APPS setting.(**We have already set.**)
+Add 'rest_framework',  'corsheaders' to your INSTALLED_APPS setting.(**We have already set.**)
 
 ```python
 INSTALLED_APPS = [
     ...
     'rest_framework',
+    'corsheaders',
 ]
 ```
+
+Add 'corsheaders.middleware.CorsMiddleware', 'django.middleware.common.CommonMiddleware' to your MIDDLEWARE setting.(**We have already set.**)
+
+```python
+MIDDLEWARE = [
+    ...
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
+]
+```
+
+Add CORS_ORIGIN_WHITELIST to your setting (for the local-environment).(**We have already set.**)
+
+```python
+CORS_ORIGIN_WHITELIST = (
+    'localhost:3000/'
+)
+```
+
 
 ### Backend Server
 

--- a/django/README.md
+++ b/django/README.md
@@ -52,9 +52,9 @@ MIDDLEWARE = [
 Add CORS_ORIGIN_WHITELIST to your setting (for the local-environment).(**We have already set.**)
 
 ```python
-CORS_ORIGIN_WHITELIST = (
-    'localhost:3000/'
-)
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:3000'
+]
 ```
 
 

--- a/django/example/settings.py
+++ b/django/example/settings.py
@@ -37,7 +37,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    # 3rd party
     'rest_framework',
+    'corsheaders',
 ]
 
 REST_FRAMEWORK = {
@@ -56,7 +58,13 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
 ]
+
+CORS_ORIGIN_WHITELIST = (
+    'localhost:3000/' #TODO: デプロイ時変更
+)
 
 ROOT_URLCONF = 'example.urls'
 
@@ -86,7 +94,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'test', #　作成したデータベース名
-        'PASSWORD':  'test', 
+        'PASSWORD': 'test', 
         'USER': 'root', # ログインユーザー
         'HOST': 'mysql', #コンテナ名
         'PORT': '3306',

--- a/django/example/settings.py
+++ b/django/example/settings.py
@@ -62,9 +62,9 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
 ]
 
-CORS_ORIGIN_WHITELIST = (
-    'localhost:3000/' #TODO: デプロイ時変更
-)
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:3000' #TODO: デプロイ時変更
+]
 
 ROOT_URLCONF = 'example.urls'
 


### PR DESCRIPTION
#3  参照
django-cors-headers (https://github.com/adamchainz/django-cors-headers) を導入

*CORS_ORIGIN_WHITELIST に vue.jsのデフォルトドメインを指定しているためデプロイ時は注意する必要がある。

あとは、サーバー側で適当にモックAPIを作って、フロント側からGetリクエストを送って上手く連携できているか確かめる。
